### PR TITLE
Update to moveit_simple_controller_manager

### DIFF
--- a/irb_2400_moveit_config/config/controllers.yaml
+++ b/irb_2400_moveit_config/config/controllers.yaml
@@ -1,8 +1,7 @@
-controller_manager_ns: pr2_controller_manager
 controller_list:
   - name: ""
-    ns: joint_trajectory_action
-    default: true
+    action_ns: joint_trajectory_action
+    type: FollowJointTrajectory
     joints:
       - joint_1
       - joint_2

--- a/irb_2400_moveit_config/launch/irb_2400_moveit_controller_manager.launch
+++ b/irb_2400_moveit_config/launch/irb_2400_moveit_controller_manager.launch
@@ -1,12 +1,6 @@
 <launch>
-  <arg name="moveit_controller_manager" default="pr2_moveit_controller_manager/Pr2MoveItControllerManager"/>
+  <arg name="moveit_controller_manager" default="moveit_simple_controller_manager/MoveItSimpleControllerManager"/>
   <param name="moveit_controller_manager" value="$(arg moveit_controller_manager)"/>
-
-  <arg name="controller_manager_name" default="pr2_controller_manager" />
-  <param name="controller_manager_name" value="$(arg controller_manager_name)"/>
-
-  <arg name="use_controller_manager" default="false" />
-  <param name="use_controller_manager" value="$(arg use_controller_manager)" />
 
   <rosparam file="$(find irb_2400_moveit_config)/config/controllers.yaml"/>
 </launch>

--- a/irb_2400_moveit_config/package.xml
+++ b/irb_2400_moveit_config/package.xml
@@ -20,6 +20,6 @@
   
   <run_depend>moveit_ros_move_group</run_depend>
   <run_depend>abb_common</run_depend>
-  <!--run_depend>abb_moveit_plugins</run_depend-->
+  <run_depend>moveit_simple_controller_manager</run_depend>
 
 </package>


### PR DESCRIPTION
Update all moveit_config packages to use moveit_simple_controller_manager, rather than the pr2_controller_manager "hack" currently used.

See ros-industrial/industrial_core#3.
