### PR TITLE
Fix unresolved simple_message symbols at link time

### DIFF
--- a/abb_common/CMakeLists.txt
+++ b/abb_common/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(abb_common)
-find_package(catkin REQUIRED COMPONENTS industrial_robot_client)
+find_package(catkin REQUIRED COMPONENTS industrial_robot_client simple_message)
 
 
 #######################################
@@ -19,7 +19,7 @@ add_definitions(-DLINUXSOCKETS=1)  #build using LINUX SOCKETS libraries
 ## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
     DEPENDS 
-    CATKIN_DEPENDS industrial_robot_client
+    CATKIN_DEPENDS industrial_robot_client simple_message
     INCLUDE_DIRS include
     LIBRARIES
 )
@@ -33,6 +33,7 @@ add_executable(abb_robot_state
   src/abb_utils.cpp)
 target_link_libraries(abb_robot_state
   industrial_robot_client 
+  simple_message
   ${catkin_LIBRARIES})
 set_target_properties(
   abb_robot_state
@@ -43,6 +44,7 @@ add_executable(abb_motion_download_interface
   src/abb_utils.cpp)
 target_link_libraries(abb_motion_download_interface
   industrial_robot_client 
+  simple_message
   ${catkin_LIBRARIES})
 set_target_properties(abb_motion_download_interface
   PROPERTIES OUTPUT_NAME motion_download_interface PREFIX "")

--- a/abb_common/package.xml
+++ b/abb_common/package.xml
@@ -10,7 +10,9 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>industrial_robot_client</build_depend>
+  <build_depend>simple_message</build_depend>
 
   <run_depend>industrial_robot_client</run_depend>
+  <run_depend>simple_message</run_depend>
   <run_depend>xacro</run_depend>
 </package>


### PR DESCRIPTION
While building against Hydro with catkin_make_isolated this issue appears [1].
As a temporary workarround we need to add simple_message explicitly on each
binary using it

[1]https://github.com/ros-industrial/industrial_core/issues/68#issue-25999936
