### PR TITLE
joint_trajectory_action is needed for MoveIt to work

### DIFF
--- a/abb_common/launch/robot_interface.launch
+++ b/abb_common/launch/robot_interface.launch
@@ -33,6 +33,6 @@
   <node pkg="abb_common" type="motion_download_interface" name="motion_download_interface"/>
   
   <!-- joint_trajectory_action: provides actionlib interface for high-level robot control -->
-<!--  <node pkg="industrial_robot_client" type="joint_trajectory_action" name="joint_trajectory_action"/> -->
+  <node pkg="industrial_robot_client" type="joint_trajectory_action" name="joint_trajectory_action"/>
 
 </launch>


### PR DESCRIPTION
Otherwise the `moveit_planning_execution.lanch` will fail in on-line mode (i.e. with the real robot).
