### PR TITLE
moveit_plugins: add depend on tf_conversions

### DIFF
--- a/abb_moveit_plugins/CMakeLists.txt
+++ b/abb_moveit_plugins/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(abb_moveit_plugins)
-find_package(catkin REQUIRED COMPONENTS moveit_core roscpp)
+find_package(catkin REQUIRED COMPONENTS moveit_core roscpp tf_conversions)
 
 #######################################
 ## Adding directories and definitions #

--- a/abb_moveit_plugins/package.xml
+++ b/abb_moveit_plugins/package.xml
@@ -10,8 +10,10 @@
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>moveit_core</build_depend>
   <build_depend>roscpp</build_depend>
+  <build_depend>tf_conversions</build_depend>
   <run_depend>moveit_core</run_depend>
   <run_depend>roscpp</run_depend>
+  <run_depend>tf_conversions</run_depend>
 
   <export>
     <moveit_core plugin="${prefix}/irb_2400_moveit_kinematics_plugin.xml"/>


### PR DESCRIPTION
`tf_conversions` is clearly referenced in the package [1] and this bug is causing failures on the buildfarm [2].

Thanks,

--scott

[1] https://github.com/ros-industrial/abb/blob/hydro-devel/abb_moveit_plugins/src/irb_2400_manipulator_ikfast_moveit_plugin.cpp#L60
[2] http://jenkins.ros.org/job/ros-hydro-abb-moveit-plugins_binarydeb_precise_amd64/
