### PR TITLE
irb2400: add depend on liblapack-dev to Moveit plugin

### DIFF
--- a/abb_irb2400_moveit_plugins/package.xml
+++ b/abb_irb2400_moveit_plugins/package.xml
@@ -27,11 +27,13 @@
   <url type="repository">https://github.com/ros-industrial/abb</url>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>liblapack-dev</build_depend>
   <build_depend>moveit_core</build_depend>
   <build_depend>pluginlib</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>tf_conversions</build_depend>
 
+  <run_depend>liblapack-dev</run_depend>
   <run_depend>moveit_core</run_depend>
   <run_depend>pluginlib</run_depend>
   <run_depend>roscpp</run_depend>


### PR DESCRIPTION
Lapack is clearly referenced at https://github.com/ros-industrial/abb/blob/hydro-devel/abb_irb2400_moveit_plugins/CMakeLists.txt#L13

The rosdep key exists at https://github.com/ros/rosdistro/blob/master/rosdep/base.yaml#L1305-L1312

Example build failure: http://csc.mcs.sdsmt.edu/jenkins/job/ros-hydro-abb-irb2400-moveit-plugins_binaryrpm_heisenbug_x86_64/2/console

Thanks,

--scott
