### PR TITLE
Fix for issue #53: missing run_depend on moveit plugins in irb2400 moveit cfg

### DIFF
--- a/abb_irb2400_moveit_config/package.xml
+++ b/abb_irb2400_moveit_config/package.xml
@@ -33,6 +33,7 @@
 
   <run_depend>industrial_robot_simulator</run_depend>
   <run_depend>abb_irb2400_support</run_depend>
+  <run_depend>abb_irb2400_moveit_plugins</run_depend>
 
   <export>
     <architecture_independent />


### PR DESCRIPTION
As per subject.

We should probably trigger a patch-fix release for the `abb` repository (concerned package is unusable like this).
