### PR TITLE
fix installation destination of plugin description

### DIFF
--- a/abb_irb2400_moveit_plugins/irb2400_kinematics/CMakeLists.txt
+++ b/abb_irb2400_moveit_plugins/irb2400_kinematics/CMakeLists.txt
@@ -12,4 +12,4 @@ install(
 
 install(
   FILES abb_irb2400_manipulator_moveit_ikfast_plugin_description.xml 
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/irb6640_kinematics)
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/irb2400_kinematics)


### PR DESCRIPTION
The plugin description used to be installed here:

/opt/ros/hydro/share/abb_irb2400_moveit_plugins/irb6640_kinematics/abb_irb2400_manipulator_moveit_ikfast_plugin_description.xml

But it's supposed to be here:

/opt/ros/hydro/share/abb_irb2400_moveit_plugins/irb2400_kinematics/abb_irb2400_manipulator_moveit_ikfast_plugin_description.xml

Also see:
https://groups.google.com/d/msg/moveit-users/LQFJwqd0N5I/eThqWkXXRMgJ
