### PR TITLE
Fix for issue #58: make moveit mongodb location configurable

### DIFF
--- a/abb_irb2400_moveit_config/launch/default_warehouse_db.launch
+++ b/abb_irb2400_moveit_config/launch/default_warehouse_db.launch
@@ -2,9 +2,12 @@
 
   <arg name="reset" default="false"/>
 
+  <!-- If not specified, we'll use a default database location -->
+  <arg name="moveit_warehouse_database_path" default="$(find abb_irb2400_moveit_config)/default_warehouse_mongo_db" />
+
   <!-- Launch the warehouse with a default database location -->  
   <include file="$(find abb_irb2400_moveit_config)/launch/warehouse.launch">
-    <arg name="moveit_warehouse_database_path" value="$(find abb_irb2400_moveit_config)/default_warehouse_mongo_db" />
+    <arg name="moveit_warehouse_database_path" value="$(arg moveit_warehouse_database_path)" />
   </include>
 
   <!-- If we want to reset the database, run this node -->

--- a/abb_irb2400_moveit_config/launch/demo.launch
+++ b/abb_irb2400_moveit_config/launch/demo.launch
@@ -2,6 +2,8 @@
 
   <!-- By default, we do not start a database (it can be large) -->
   <arg name="db" default="false" />
+  <!-- Allow user to specify database location -->
+  <arg name="db_path" default="$(find abb_irb2400_moveit_config)/default_warehouse_mongo_db" />
 
   <!-- By default, we are not in debug mode -->
   <arg name="debug" default="false" />
@@ -38,6 +40,8 @@
   </include>
 
   <!-- If database loading was enabled, start mongodb as well -->
-  <include file="$(find abb_irb2400_moveit_config)/launch/default_warehouse_db.launch" if="$(arg db)"/>
+  <include file="$(find abb_irb2400_moveit_config)/launch/default_warehouse_db.launch" if="$(arg db)">
+    <arg name="moveit_warehouse_database_path" value="$(arg db_path)"/>
+  </include>
 
 </launch>

--- a/abb_irb2400_moveit_config/launch/moveit_planning_execution.launch
+++ b/abb_irb2400_moveit_config/launch/moveit_planning_execution.launch
@@ -14,6 +14,11 @@
   <arg name="sim" default="true" />
   <arg name="robot_ip" unless="$(arg sim)" />
 
+  <!-- By default, we do not start a database (it can be large) -->
+  <arg name="db" default="false" />
+  <!-- Allow user to specify database location -->
+  <arg name="db_path" default="$(find abb_irb2400_moveit_config)/default_warehouse_mongo_db" />
+
   <!-- load the robot_description parameter before launching ROS-I nodes -->
   <include file="$(find abb_irb2400_moveit_config)/launch/planning_context.launch" >
     <arg name="load_robot_description" value="true" />
@@ -43,7 +48,10 @@
   <include file="$(find abb_irb2400_moveit_config)/launch/moveit_rviz.launch">
     <arg name="config" value="true"/>
   </include>
-  
-  <include file="$(find abb_irb2400_moveit_config)/launch/default_warehouse_db.launch" />
+
+  <!-- If database loading was enabled, start mongodb as well -->
+  <include file="$(find abb_irb2400_moveit_config)/launch/default_warehouse_db.launch" if="$(arg db)">
+    <arg name="moveit_warehouse_database_path" value="$(arg db_path)"/>
+  </include>
 
 </launch>

--- a/abb_irb6640_moveit_config/launch/default_warehouse_db.launch
+++ b/abb_irb6640_moveit_config/launch/default_warehouse_db.launch
@@ -2,9 +2,12 @@
 
   <arg name="reset" default="false"/>
 
+  <!-- If not specified, we'll use a default database location -->
+  <arg name="moveit_warehouse_database_path" default="$(find abb_irb6640_moveit_config)/default_warehouse_mongo_db" />
+
   <!-- Launch the warehouse with a default database location -->  
   <include file="$(find abb_irb6640_moveit_config)/launch/warehouse.launch">
-    <arg name="moveit_warehouse_database_path" value="$(find abb_irb6640_moveit_config)/default_warehouse_mongo_db" />
+    <arg name="moveit_warehouse_database_path" value="$(arg moveit_warehouse_database_path)" />
   </include>
 
   <!-- If we want to reset the database, run this node -->

--- a/abb_irb6640_moveit_config/launch/demo.launch
+++ b/abb_irb6640_moveit_config/launch/demo.launch
@@ -2,6 +2,8 @@
 
   <!-- By default, we do not start a database (it can be large) -->
   <arg name="db" default="false" />
+  <!-- Allow user to specify database location -->
+  <arg name="db_path" default="$(find abb_irb6640_moveit_config)/default_warehouse_mongo_db" />
 
   <!-- By default, we are not in debug mode -->
   <arg name="debug" default="false" />
@@ -38,6 +40,8 @@
   </include>
 
   <!-- If database loading was enabled, start mongodb as well -->
-  <include file="$(find abb_irb6640_moveit_config)/launch/default_warehouse_db.launch" if="$(arg db)"/>
+  <include file="$(find abb_irb6640_moveit_config)/launch/default_warehouse_db.launch" if="$(arg db)">
+    <arg name="moveit_warehouse_database_path" value="$(arg db_path)"/>
+  </include>
 
 </launch>

--- a/abb_irb6640_moveit_config/launch/moveit_planning_execution.launch
+++ b/abb_irb6640_moveit_config/launch/moveit_planning_execution.launch
@@ -14,6 +14,11 @@
   <arg name="sim" default="true" />
   <arg name="robot_ip" unless="$(arg sim)" />
 
+  <!-- By default, we do not start a database (it can be large) -->
+  <arg name="db" default="false" />
+  <!-- Allow user to specify database location -->
+  <arg name="db_path" default="$(find abb_irb6640_moveit_config)/default_warehouse_mongo_db" />
+
   <!-- load the robot_description parameter before launching ROS-I nodes -->
   <include file="$(find abb_irb6640_moveit_config)/launch/planning_context.launch" >
     <arg name="load_robot_description" value="true" />
@@ -43,7 +48,10 @@
   <include file="$(find abb_irb6640_moveit_config)/launch/moveit_rviz.launch">
     <arg name="config" value="true"/>
   </include>
-  
-  <include file="$(find abb_irb6640_moveit_config)/launch/default_warehouse_db.launch" />
+
+  <!-- If database loading was enabled, start mongodb as well -->
+  <include file="$(find abb_irb6640_moveit_config)/launch/default_warehouse_db.launch" if="$(arg db)">
+    <arg name="moveit_warehouse_database_path" value="$(arg db_path)"/>
+  </include>
 
 </launch>

--- a/irb_2400_moveit_config/launch/default_warehouse_db.launch
+++ b/irb_2400_moveit_config/launch/default_warehouse_db.launch
@@ -2,9 +2,12 @@
 
   <arg name="reset" default="false"/>
 
+  <!-- If not specified, we'll use a default database location -->
+  <arg name="moveit_warehouse_database_path" default="$(find irb_2400_moveit_config)/default_warehouse_mongo_db" />
+
   <!-- Launch the warehouse with a default database location -->  
   <include file="$(find irb_2400_moveit_config)/launch/warehouse.launch">
-    <arg name="moveit_warehouse_database_path" value="$(find irb_2400_moveit_config)/default_warehouse_mongo_db" />
+    <arg name="moveit_warehouse_database_path" value="$(arg moveit_warehouse_database_path)" />
   </include>
 
   <!-- If we want to reset the database, run this node -->

--- a/irb_2400_moveit_config/launch/demo.launch
+++ b/irb_2400_moveit_config/launch/demo.launch
@@ -1,5 +1,10 @@
 <launch>
 
+  <!-- By default, we do not start a database (it can be large) -->
+  <arg name="db" default="false" />
+  <!-- Allow user to specify database location -->
+  <arg name="db_path" default="$(find irb_2400_moveit_config)/default_warehouse_mongo_db" />
+
   <include file="$(find irb_2400_moveit_config)/launch/planning_context.launch">
     <arg name="load_robot_description" value="true"/>
   </include>
@@ -20,6 +25,9 @@
     <arg name="config" value="true"/>
   </include>
 
-  <include file="$(find irb_2400_moveit_config)/launch/default_warehouse_db.launch" />
+  <!-- If database loading was enabled, start mongodb as well -->
+  <include file="$(find irb_2400_moveit_config)/launch/default_warehouse_db.launch" if="$(arg db)">
+    <arg name="moveit_warehouse_database_path" value="$(arg db_path)"/>
+  </include>
 
 </launch>

--- a/irb_2400_moveit_config/launch/moveit_planning_execution.launch
+++ b/irb_2400_moveit_config/launch/moveit_planning_execution.launch
@@ -6,7 +6,12 @@
   <!--  - if sim=false, a robot_ip argument is required -->
   <arg name="sim" default="true" />
   <arg name="robot_ip" unless="$(arg sim)" />
- 
+
+  <!-- By default, we do not start a database (it can be large) -->
+  <arg name="db" default="false" />
+  <!-- Allow user to specify database location -->
+  <arg name="db_path" default="$(find irb_2400_moveit_config)/default_warehouse_mongo_db" />
+
   <!-- load the robot_description parameter before launching ROS-I nodes -->
   <include file="$(find irb_2400_moveit_config)/launch/planning_context.launch" >
     <arg name="load_robot_description" value="true" />
@@ -37,8 +42,11 @@
   <include file="$(find irb_2400_moveit_config)/launch/moveit_rviz.launch">
     <arg name="config" value="true" />
   </include>
-  
-  <include file="$(find irb_2400_moveit_config)/launch/default_warehouse_db.launch" />
+
+  <!-- If database loading was enabled, start mongodb as well -->
+  <include file="$(find irb_2400_moveit_config)/launch/default_warehouse_db.launch" if="$(arg db)">
+    <arg name="moveit_warehouse_database_path" value="$(arg db_path)"/>
+  </include>
 
 </launch>
 

--- a/irb_6640_moveit_config/launch/default_warehouse_db.launch
+++ b/irb_6640_moveit_config/launch/default_warehouse_db.launch
@@ -2,9 +2,12 @@
 
   <arg name="reset" default="false"/>
 
+  <!-- If not specified, we'll use a default database location -->
+  <arg name="moveit_warehouse_database_path" default="$(find irb_6640_moveit_config)/default_warehouse_mongo_db" />
+
   <!-- Launch the warehouse with a default database location -->  
   <include file="$(find irb_6640_moveit_config)/launch/warehouse.launch">
-    <arg name="moveit_warehouse_database_path" value="$(find irb_6640_moveit_config)/default_warehouse_mongo_db" />
+    <arg name="moveit_warehouse_database_path" value="$(arg moveit_warehouse_database_path)" />
   </include>
 
   <!-- If we want to reset the database, run this node -->

--- a/irb_6640_moveit_config/launch/demo.launch
+++ b/irb_6640_moveit_config/launch/demo.launch
@@ -2,6 +2,8 @@
 
   <!-- By default, we do not start a database (it can be large) -->
   <arg name="db" default="false" />
+  <!-- Allow user to specify database location -->
+  <arg name="db_path" default="$(find irb_6640_moveit_config)/default_warehouse_mongo_db" />
 
   <!-- By default, we are not in debug mode -->
   <arg name="debug" default="false" />
@@ -38,6 +40,8 @@
   </include>
 
   <!-- If database loading was enabled, start mongodb as well -->
-  <include file="$(find irb_6640_moveit_config)/launch/default_warehouse_db.launch" if="$(arg db)"/>
+  <include file="$(find irb_6640_moveit_config)/launch/default_warehouse_db.launch" if="$(arg db)">
+    <arg name="moveit_warehouse_database_path" value="$(arg db_path)"/>
+  </include>
 
 </launch>

--- a/irb_6640_moveit_config/launch/moveit_planning_execution.launch
+++ b/irb_6640_moveit_config/launch/moveit_planning_execution.launch
@@ -35,7 +35,7 @@
 </include>
  
  
- <include file="$(find irb_6640_moveit_config)/launch/default_warehouse_db.launch" />
+ <include file="$(find irb_6640_moveit_config)/launch/default_warehouse_db.launch" if="$(arg db)" />
 
  
 


### PR DESCRIPTION
As per subject.

See also earlier discussion in #59.

I've also added these changes to the _deprecated_ `irb2400_..` and `irb6640_..` MoveIt pkgs.
