### PR TITLE
Fix for issue #42: driver was checking for wrong comm type to send reply message

### DIFF
--- a/abb_driver/rapid/ROS_motionServer.mod
+++ b/abb_driver/rapid/ROS_motionServer.mod
@@ -88,7 +88,7 @@ LOCAL PROC trajectory_pt_callback(ROS_msg_joint_traj_pt message)
 	ENDTEST
 
     ! send reply, if requested
-    IF (message.header.comm_type = ROS_COM_TYPE_SRV_REPLY) THEN
+    IF (message.header.comm_type = ROS_COM_TYPE_SRV_REQ) THEN
         reply_msg.header := [ROS_MSG_TYPE_JOINT_TRAJ_PT, ROS_COM_TYPE_SRV_REPLY, ROS_REPLY_TYPE_SUCCESS];
         ROS_send_msg client_socket, reply_msg;
     ENDIF


### PR DESCRIPTION
After a trajectory stop command was sent to the abb driver the user was unable to send any new trajectories to the abb driver. The issue was that trajectoryStop function within ROS was waiting for a reply message that the abb driver never sent because it was looking for the wrong comm type to send a reply message.

The comm type required to send a reply message was changed from ROS_COM_TYPE_SRV_REPLY to ROS_COM_TYPE_SRV_REQ fixing the issue.
