### PR TITLE
Fix for issue #49: add 'base' link (transform to World)

### DIFF
--- a/abb_common/urdf/irb_2400.urdf
+++ b/abb_common/urdf/irb_2400.urdf
@@ -179,5 +179,11 @@
     <child link="tool0"/>
     <origin rpy="0 0 0" xyz="0 0 0"/>
   </joint>
+  <link name="base"/>
+  <joint name="base_link-base" type="fixed">
+    <origin rpy="0 0 0" xyz="0 0 0"/>
+    <parent link="base_link"/>
+    <child link="base"/>
+  </joint>
 </robot>
 

--- a/abb_common/urdf/irb_2400_macro.xacro
+++ b/abb_common/urdf/irb_2400_macro.xacro
@@ -300,6 +300,14 @@
 			<child link="${prefix}tool0"/>
 			<origin xyz="0 0 0" rpy="0 0 0"/>
 		</joint>
-		<!-- end of joint list -->
+                <!-- end of joint list -->
+
+                <!-- ROS base_link to ABB World Coordinates transform -->
+                <link name="${prefix}base" />
+                <joint name="${prefix}base_link-base" type="fixed">
+                        <origin xyz="0 0 0" rpy="0 0 0"/>
+                        <parent link="${prefix}base_link"/>
+                        <child link="${prefix}base"/>
+                </joint>
 	</xacro:macro>
 </robot>

--- a/abb_common/urdf/irb_5400.urdf
+++ b/abb_common/urdf/irb_5400.urdf
@@ -178,4 +178,10 @@
     <child link="tool0"/>
     <origin rpy="0.0 0.6109 0.0" xyz="0.0672 0 -0.0470"/>
   </joint>
+  <link name="base"/>
+  <joint name="base_link-base" type="fixed">
+    <origin rpy="0 0 0" xyz="0 0 0"/>
+    <parent link="base_link"/>
+    <child link="base"/>
+  </joint>
 </robot>

--- a/abb_common/urdf/irb_5400_macro.xacro
+++ b/abb_common/urdf/irb_5400_macro.xacro
@@ -197,5 +197,13 @@
     </joint>
 
     <!-- end of joint list -->
+
+    <!-- ROS base_link to ABB World Coordinates transform -->
+    <link name="${prefix}base" />
+    <joint name="${prefix}base_link-base" type="fixed">
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <parent link="${prefix}base_link"/>
+      <child link="${prefix}base"/>
+    </joint>
   </xacro:macro>
 </robot>

--- a/abb_common/urdf/irb_6640.urdf
+++ b/abb_common/urdf/irb_6640.urdf
@@ -197,5 +197,11 @@
     <child link="link_piston"/>
     <limit effort="0" lower="0" upper="0.6" velocity="0"/>
   </joint>
+  <link name="base"/>
+  <joint name="base_link-base" type="fixed">
+    <origin rpy="0 0 0" xyz="0 0 0"/>
+    <parent link="base_link"/>
+    <child link="base"/>
+  </joint>
 </robot>
 

--- a/abb_common/urdf/irb_6640_macro.xacro
+++ b/abb_common/urdf/irb_6640_macro.xacro
@@ -223,5 +223,13 @@
   </joint>
 
    <!-- end of joint list -->
+
+  <!-- ROS base_link to ABB World Coordinates transform -->
+  <link name="${prefix}base" />
+  <joint name="${prefix}base_link-base" type="fixed">
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+    <parent link="${prefix}base_link"/>
+    <child link="${prefix}base"/>
+  </joint>
   </xacro:macro>
 </robot>

--- a/abb_irb2400_support/urdf/irb2400.urdf
+++ b/abb_irb2400_support/urdf/irb2400.urdf
@@ -179,5 +179,11 @@
     <child link="tool0"/>
     <origin rpy="0 0 0" xyz="0 0 0"/>
   </joint>
+  <link name="base"/>
+  <joint name="base_link-base" type="fixed">
+    <origin rpy="0 0 0" xyz="0 0 0"/>
+    <parent link="base_link"/>
+    <child link="base"/>
+  </joint>
 </robot>
 

--- a/abb_irb2400_support/urdf/irb2400_macro.xacro
+++ b/abb_irb2400_support/urdf/irb2400_macro.xacro
@@ -181,5 +181,13 @@
         <origin xyz="0 0 0" rpy="0 0 0"/>
     </joint>
     <!-- end of joint list -->
+
+    <!-- ROS base_link to ABB World Coordinates transform -->
+    <link name="${prefix}base" />
+    <joint name="${prefix}base_link-base" type="fixed">
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <parent link="${prefix}base_link"/>
+        <child link="${prefix}base"/>
+    </joint>
 </xacro:macro>
 </robot>

--- a/abb_irb5400_support/urdf/irb5400.urdf
+++ b/abb_irb5400_support/urdf/irb5400.urdf
@@ -178,4 +178,10 @@
     <child link="tool0"/>
     <origin rpy="0.0 0.6109 0.0" xyz="0.0672 0 -0.0470"/>
   </joint>
+  <link name="base"/>
+  <joint name="base_link-base" type="fixed">
+    <origin rpy="0 0 0" xyz="0 0 0"/>
+    <parent link="base_link"/>
+    <child link="base"/>
+  </joint>
 </robot>

--- a/abb_irb5400_support/urdf/irb5400_macro.xacro
+++ b/abb_irb5400_support/urdf/irb5400_macro.xacro
@@ -180,5 +180,13 @@
         <origin xyz="0.0672 0 -0.0470" rpy="0.0 0.6109 0.0"/>
     </joint>
     <!-- end of joint list -->
+
+    <!-- ROS base_link to ABB World Coordinates transform -->
+    <link name="${prefix}base" />
+    <joint name="${prefix}base_link-base" type="fixed">
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <parent link="${prefix}base_link"/>
+        <child link="${prefix}base"/>
+    </joint>
 </xacro:macro>
 </robot>

--- a/abb_irb6600_support/urdf/irb6640.urdf
+++ b/abb_irb6600_support/urdf/irb6640.urdf
@@ -197,5 +197,11 @@
     <child link="link_piston"/>
     <limit effort="0" lower="0" upper="0.6" velocity="0"/>
   </joint>
+  <link name="base"/>
+  <joint name="base_link-base" type="fixed">
+    <origin rpy="0 0 0" xyz="0 0 0"/>
+    <parent link="base_link"/>
+    <child link="base"/>
+  </joint>
 </robot>
 

--- a/abb_irb6600_support/urdf/irb6640_macro.xacro
+++ b/abb_irb6600_support/urdf/irb6640_macro.xacro
@@ -201,5 +201,13 @@
         <limit effort="0" lower="0" upper="0.6" velocity="0"/>
     </joint>
     <!-- end of joint list -->
+
+    <!-- ROS base_link to ABB World Coordinates transform -->
+    <link name="${prefix}base" />
+    <joint name="${prefix}base_link-base" type="fixed">
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <parent link="${prefix}base_link"/>
+        <child link="${prefix}base"/>
+    </joint>
 </xacro:macro>
 </robot>


### PR DESCRIPTION
This should not affect existing kinematic plugins or MoveIt configurations:
- the link is not part of the main kinematic chain
- the transform is implemented as a fixed joint
