### PR TITLE
Fix #32: corrects tool0 to match robot controller

### DIFF
--- a/abb_irb2400_support/urdf/irb2400.urdf
+++ b/abb_irb2400_support/urdf/irb2400.urdf
@@ -119,6 +119,7 @@
       <material name="yellow"/>
     </collision>
   </link>
+  <link name="mount_flange"/>
   <link name="tool0"/>
   <joint name="joint_1" type="revolute">
     <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -174,8 +175,13 @@
     <calibration falling="0" rising="0"/>
     <dynamics damping="0" friction="0"/>
   </joint>
-  <joint name="joint_6-tool0" type="fixed">
+  <joint name="joint_6-mount_flange" type="fixed">
     <parent link="link_6"/>
+    <child link="mount_flange"/>
+    <origin rpy="0 1.57079632679 0" xyz="0 0 0"/>
+  </joint>
+  <joint name="mount_flange-tool0" type="fixed">
+    <parent link="mount_flange"/>
     <child link="tool0"/>
     <origin rpy="0 0 0" xyz="0 0 0"/>
   </joint>

--- a/abb_irb2400_support/urdf/irb2400.urdf
+++ b/abb_irb2400_support/urdf/irb2400.urdf
@@ -119,7 +119,6 @@
       <material name="yellow"/>
     </collision>
   </link>
-  <link name="mount_flange"/>
   <link name="tool0"/>
   <joint name="joint_1" type="revolute">
     <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -127,8 +126,6 @@
     <child link="link_1"/>
     <axis xyz="0 0 1"/>
     <limit effort="0" lower="-3.1416" upper="3.1416" velocity="2.618"/>
-    <calibration falling="0" rising="0"/>
-    <dynamics damping="0" friction="0"/>
   </joint>
   <joint name="joint_2" type="revolute">
     <origin rpy="0 0 0" xyz="0.1 0 0.615"/>
@@ -136,8 +133,6 @@
     <child link="link_2"/>
     <axis xyz="0 1 0"/>
     <limit effort="0" lower="-1.7453" upper="1.9199" velocity="2.618"/>
-    <calibration falling="0" rising="0"/>
-    <dynamics damping="0" friction="0"/>
   </joint>
   <joint name="joint_3" type="revolute">
     <origin rpy="0 0 0" xyz="0 0 0.705"/>
@@ -145,8 +140,6 @@
     <child link="link_3"/>
     <axis xyz="0 1 0"/>
     <limit effort="0" lower="-1.0472" upper="1.1345" velocity="2.618"/>
-    <calibration falling="0" rising="0"/>
-    <dynamics damping="0" friction="0"/>
   </joint>
   <joint name="joint_4" type="revolute">
     <origin rpy="0 0 0" xyz="0.258 0 0.135"/>
@@ -154,8 +147,6 @@
     <child link="link_4"/>
     <axis xyz="1 0 0"/>
     <limit effort="0" lower="-3.49" upper="3.49" velocity="6.2832"/>
-    <calibration falling="0" rising="0"/>
-    <dynamics damping="0" friction="0"/>
   </joint>
   <joint name="joint_5" type="revolute">
     <origin rpy="0 0 0" xyz="0.497 0 0"/>
@@ -163,8 +154,6 @@
     <child link="link_5"/>
     <axis xyz="0 1 0"/>
     <limit effort="0" lower="-2.0944" upper="2.0944" velocity="6.2832"/>
-    <calibration falling="0" rising="0"/>
-    <dynamics damping="0" friction="0"/>
   </joint>
   <joint name="joint_6" type="revolute">
     <origin rpy="0 0 0" xyz="0.085 0 0"/>
@@ -172,18 +161,11 @@
     <child link="link_6"/>
     <axis xyz="1 0 0"/>
     <limit effort="0" lower="-6.9813" upper="6.9813" velocity="7.854"/>
-    <calibration falling="0" rising="0"/>
-    <dynamics damping="0" friction="0"/>
   </joint>
-  <joint name="joint_6-mount_flange" type="fixed">
+  <joint name="joint_6-tool0" type="fixed">
     <parent link="link_6"/>
-    <child link="mount_flange"/>
-    <origin rpy="0 1.57079632679 0" xyz="0 0 0"/>
-  </joint>
-  <joint name="mount_flange-tool0" type="fixed">
-    <parent link="mount_flange"/>
     <child link="tool0"/>
-    <origin rpy="0 0 0" xyz="0 0 0"/>
+    <origin rpy="0 1.57079632679 0" xyz="0 0 0"/>
   </joint>
   <link name="base"/>
   <joint name="base_link-base" type="fixed">

--- a/abb_irb2400_support/urdf/irb2400_macro.xacro
+++ b/abb_irb2400_support/urdf/irb2400_macro.xacro
@@ -117,7 +117,6 @@
             <material name="yellow"/>
         </collision>
     </link>
-    <link name="${prefix}mount_flange"/>
     <link name="${prefix}tool0"/>
     <!-- end of link list -->
 
@@ -128,8 +127,6 @@
         <child link="${prefix}link_1"/>
         <axis xyz="0 0 1"/>
         <limit lower="-3.1416" upper="3.1416" effort="0" velocity="2.618"/>
-        <calibration rising="0" falling="0"/>
-        <dynamics damping="0" friction="0"/>
     </joint>
     <joint name="${prefix}joint_2" type="revolute">
         <origin xyz="0.1 0 0.615" rpy="0 0 0"/>
@@ -137,8 +134,6 @@
         <child link="${prefix}link_2"/>
         <axis xyz="0 1 0"/>
         <limit lower="-1.7453" upper="1.9199" effort="0" velocity="2.618"/>
-        <calibration rising="0" falling="0"/>
-        <dynamics damping="0" friction="0"/>
     </joint>
     <joint name="${prefix}joint_3" type="revolute">
         <origin xyz="0 0 0.705" rpy="0 0 0"/>
@@ -146,8 +141,6 @@
         <child link="${prefix}link_3"/>
         <axis xyz="0 1 0"/>
         <limit lower="-1.0472" upper="1.1345" effort="0" velocity="2.618"/>
-        <calibration rising="0" falling="0"/>
-        <dynamics damping="0" friction="0"/>
     </joint>
     <joint name="${prefix}joint_4" type="revolute">
         <origin xyz="0.258 0 0.135" rpy="0 0 0"/>
@@ -155,8 +148,6 @@
         <child link="${prefix}link_4"/>
         <axis xyz="1 0 0"/>
         <limit lower="-3.49" upper="3.49" effort="0" velocity="6.2832"/>
-        <calibration rising="0" falling="0"/>
-        <dynamics damping="0" friction="0"/>
     </joint>
     <joint name="${prefix}joint_5" type="revolute">
         <origin xyz="0.497 0 0" rpy="0 0 0"/>
@@ -164,8 +155,6 @@
         <child link="${prefix}link_5"/>
         <axis xyz="0 1 0"/>
         <limit lower="-2.0944" upper="2.0944" effort="0" velocity="6.2832"/>
-        <calibration rising="0" falling="0"/>
-        <dynamics damping="0" friction="0"/>
     </joint>
     <joint name="${prefix}joint_6" type="revolute">
         <origin xyz="0.085 0 0" rpy="0 0 0"/>
@@ -173,18 +162,11 @@
         <child link="${prefix}link_6"/>
         <axis xyz="1 0 0"/>
         <limit lower="-6.9813" upper="6.9813" effort="0" velocity="7.854"/>
-        <calibration rising="0" falling="0"/>
-        <dynamics damping="0" friction="0"/>
     </joint>
-    <joint name="${prefix}joint_6-mount_flange" type="fixed">
+    <joint name="${prefix}joint_6-tool0" type="fixed">
         <parent link="${prefix}link_6"/>
-        <child link="${prefix}mount_flange"/>
-        <origin xyz="0 0 0" rpy="0 1.57079632679 0"/>
-    </joint>
-    <joint name="${prefix}mount_flange-tool0" type="fixed">
-        <parent link="${prefix}mount_flange"/>
         <child link="${prefix}tool0"/>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <origin xyz="0 0 0" rpy="0 1.57079632679 0"/>
     </joint>
     <!-- end of joint list -->
 

--- a/abb_irb2400_support/urdf/irb2400_macro.xacro
+++ b/abb_irb2400_support/urdf/irb2400_macro.xacro
@@ -117,6 +117,7 @@
             <material name="yellow"/>
         </collision>
     </link>
+    <link name="${prefix}mount_flange"/>
     <link name="${prefix}tool0"/>
     <!-- end of link list -->
 
@@ -175,8 +176,13 @@
         <calibration rising="0" falling="0"/>
         <dynamics damping="0" friction="0"/>
     </joint>
-    <joint name="${prefix}joint_6-tool0" type="fixed">
+    <joint name="${prefix}joint_6-mount_flange" type="fixed">
         <parent link="${prefix}link_6"/>
+        <child link="${prefix}mount_flange"/>
+        <origin xyz="0 0 0" rpy="0 1.57079632679 0"/>
+    </joint>
+    <joint name="${prefix}mount_flange-tool0" type="fixed">
+        <parent link="${prefix}mount_flange"/>
         <child link="${prefix}tool0"/>
         <origin xyz="0 0 0" rpy="0 0 0"/>
     </joint>

--- a/abb_irb5400_support/urdf/irb5400.urdf
+++ b/abb_irb5400_support/urdf/irb5400.urdf
@@ -122,6 +122,7 @@
       <material name="yellow"/>
     </collision>
   </link>
+  <link name="mount_flange"/>
   <link name="tool0"/>
   <joint name="joint1" type="revolute">
     <parent link="base_link"/>
@@ -173,10 +174,15 @@
     <axis xyz="1 0 0"/>
     <limit effort="100" lower="-6.0" upper="6.0" velocity="9.3375"/>
   </joint>
-  <joint name="joint_6-tool0" type="fixed">
+  <joint name="joint_6-mount_flange" type="fixed">
     <parent link="link_6"/>
+    <child link="mount_flange"/>
+    <origin rpy="0 1.57079632679 0" xyz="0 0 0"/>
+  </joint>
+  <joint name="mount_flange-tool0" type="fixed">
+    <parent link="mount_flange"/>
     <child link="tool0"/>
-    <origin rpy="0.0 0.6109 0.0" xyz="0.0672 0 -0.0470"/>
+    <origin rpy="0 0 0" xyz="0 0 0"/>
   </joint>
   <link name="base"/>
   <joint name="base_link-base" type="fixed">
@@ -185,3 +191,4 @@
     <child link="base"/>
   </joint>
 </robot>
+

--- a/abb_irb5400_support/urdf/irb5400.urdf
+++ b/abb_irb5400_support/urdf/irb5400.urdf
@@ -122,7 +122,6 @@
       <material name="yellow"/>
     </collision>
   </link>
-  <link name="mount_flange"/>
   <link name="tool0"/>
   <joint name="joint1" type="revolute">
     <parent link="base_link"/>
@@ -174,15 +173,10 @@
     <axis xyz="1 0 0"/>
     <limit effort="100" lower="-6.0" upper="6.0" velocity="9.3375"/>
   </joint>
-  <joint name="joint_6-mount_flange" type="fixed">
+  <joint name="joint_6-tool0" type="fixed">
     <parent link="link_6"/>
-    <child link="mount_flange"/>
-    <origin rpy="0 1.57079632679 0" xyz="0 0 0"/>
-  </joint>
-  <joint name="mount_flange-tool0" type="fixed">
-    <parent link="mount_flange"/>
     <child link="tool0"/>
-    <origin rpy="0 0 0" xyz="0 0 0"/>
+    <origin rpy="0 1.57079632679 0" xyz="0 0 0"/>
   </joint>
   <link name="base"/>
   <joint name="base_link-base" type="fixed">

--- a/abb_irb5400_support/urdf/irb5400_macro.xacro
+++ b/abb_irb5400_support/urdf/irb5400_macro.xacro
@@ -120,6 +120,7 @@
             <material name="yellow"/>
         </collision>
     </link>
+    <link name="${prefix}mount_flange"/>
     <link name="${prefix}tool0"/>
     <!-- end of link list -->
 
@@ -174,10 +175,15 @@
         <axis xyz="1 0 0"/>
         <limit lower="-6.0" upper="6.0" effort="100" velocity="9.3375"/>
     </joint>
-    <joint name="${prefix}joint_6-tool0" type="fixed">
+    <joint name="${prefix}joint_6-mount_flange" type="fixed">
         <parent link="${prefix}link_6"/>
+        <child link="${prefix}mount_flange"/>
+        <origin xyz="0 0 0" rpy="0 1.57079632679 0"/>
+    </joint>
+    <joint name="${prefix}mount_flange-tool0" type="fixed">
+        <parent link="${prefix}mount_flange"/>
         <child link="${prefix}tool0"/>
-        <origin xyz="0.0672 0 -0.0470" rpy="0.0 0.6109 0.0"/>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
     </joint>
     <!-- end of joint list -->
 

--- a/abb_irb5400_support/urdf/irb5400_macro.xacro
+++ b/abb_irb5400_support/urdf/irb5400_macro.xacro
@@ -120,7 +120,6 @@
             <material name="yellow"/>
         </collision>
     </link>
-    <link name="${prefix}mount_flange"/>
     <link name="${prefix}tool0"/>
     <!-- end of link list -->
 
@@ -175,15 +174,10 @@
         <axis xyz="1 0 0"/>
         <limit lower="-6.0" upper="6.0" effort="100" velocity="9.3375"/>
     </joint>
-    <joint name="${prefix}joint_6-mount_flange" type="fixed">
+    <joint name="${prefix}joint_6-tool0" type="fixed">
         <parent link="${prefix}link_6"/>
-        <child link="${prefix}mount_flange"/>
-        <origin xyz="0 0 0" rpy="0 1.57079632679 0"/>
-    </joint>
-    <joint name="${prefix}mount_flange-tool0" type="fixed">
-        <parent link="${prefix}mount_flange"/>
         <child link="${prefix}tool0"/>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <origin xyz="0 0 0" rpy="0 1.57079632679 0"/>
     </joint>
     <!-- end of joint list -->
 

--- a/abb_irb6600_support/urdf/irb6640.urdf
+++ b/abb_irb6600_support/urdf/irb6640.urdf
@@ -106,6 +106,7 @@
       <material name="orange"/>
     </visual>
   </link>
+  <link name="mount_flange"/>
   <link name="tool0"/>
   <link name="link_cylinder">
     <collision name="collision">
@@ -177,11 +178,15 @@
     <child link="link_6"/>
     <limit effort="0" lower="-6.283" upper="6.283" velocity="3.3161"/>
   </joint>
-  <joint name="joint_6-tool0" type="fixed">
-    <origin rpy="0 0 0" xyz=".055 0 0 "/>
-    <axis xyz="1 0 0"/>
+  <joint name="joint_6-mount_flange" type="fixed">
     <parent link="link_6"/>
+    <child link="mount_flange"/>
+    <origin rpy="0 1.57079632679 0" xyz=".055 0 0"/>
+  </joint>
+  <joint name="mount_flange-tool0" type="fixed">
+    <parent link="mount_flange"/>
     <child link="tool0"/>
+    <origin rpy="0 0 0" xyz="0 0 0"/>
   </joint>
   <joint name="joint_cylinder" type="fixed">
     <origin rpy="0 -0.170 0" xyz="-0.365 -0.1895 0.405"/>

--- a/abb_irb6600_support/urdf/irb6640.urdf
+++ b/abb_irb6600_support/urdf/irb6640.urdf
@@ -106,7 +106,6 @@
       <material name="orange"/>
     </visual>
   </link>
-  <link name="mount_flange"/>
   <link name="tool0"/>
   <link name="link_cylinder">
     <collision name="collision">
@@ -178,15 +177,10 @@
     <child link="link_6"/>
     <limit effort="0" lower="-6.283" upper="6.283" velocity="3.3161"/>
   </joint>
-  <joint name="joint_6-mount_flange" type="fixed">
+  <joint name="joint_6-tool0" type="fixed">
     <parent link="link_6"/>
-    <child link="mount_flange"/>
-    <origin rpy="0 1.57079632679 0" xyz=".055 0 0"/>
-  </joint>
-  <joint name="mount_flange-tool0" type="fixed">
-    <parent link="mount_flange"/>
     <child link="tool0"/>
-    <origin rpy="0 0 0" xyz="0 0 0"/>
+    <origin rpy="0 1.57079632679 0" xyz=".055 0 0"/>
   </joint>
   <joint name="joint_cylinder" type="fixed">
     <origin rpy="0 -0.170 0" xyz="-0.365 -0.1895 0.405"/>

--- a/abb_irb6600_support/urdf/irb6640_macro.xacro
+++ b/abb_irb6600_support/urdf/irb6640_macro.xacro
@@ -104,6 +104,7 @@
             <material name="orange"/>
         </visual>
     </link>
+    <link name="${prefix}mount_flange"/>
     <link name="${prefix}tool0"/>
 
     <!--Cylinder and piston -->
@@ -180,11 +181,15 @@
         <child link="${prefix}link_6"/>
         <limit effort="0" lower="-6.283" upper="6.283" velocity="3.3161"/>
     </joint>
-    <joint type="fixed" name="joint_6-tool0">
-        <origin xyz=".055 0 0 " rpy="0 0 0"/>
-        <axis xyz="1 0 0"/>
+    <joint type="fixed" name="${prefix}joint_6-mount_flange">
         <parent link="${prefix}link_6"/>
+        <child link="${prefix}mount_flange"/>
+        <origin xyz=".055 0 0" rpy="0 1.57079632679 0"/>
+    </joint>
+    <joint type="fixed" name="${prefix}mount_flange-tool0">
+        <parent link="${prefix}mount_flange"/>
         <child link="${prefix}tool0"/>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
     </joint>
     <joint type="fixed" name="${prefix}joint_cylinder">
         <origin xyz="-0.365 -0.1895 0.405" rpy="0 -0.170 0"/>

--- a/abb_irb6600_support/urdf/irb6640_macro.xacro
+++ b/abb_irb6600_support/urdf/irb6640_macro.xacro
@@ -104,7 +104,6 @@
             <material name="orange"/>
         </visual>
     </link>
-    <link name="${prefix}mount_flange"/>
     <link name="${prefix}tool0"/>
 
     <!--Cylinder and piston -->
@@ -181,15 +180,10 @@
         <child link="${prefix}link_6"/>
         <limit effort="0" lower="-6.283" upper="6.283" velocity="3.3161"/>
     </joint>
-    <joint type="fixed" name="${prefix}joint_6-mount_flange">
+    <joint type="fixed" name="${prefix}joint_6-tool0">
         <parent link="${prefix}link_6"/>
-        <child link="${prefix}mount_flange"/>
-        <origin xyz=".055 0 0" rpy="0 1.57079632679 0"/>
-    </joint>
-    <joint type="fixed" name="${prefix}mount_flange-tool0">
-        <parent link="${prefix}mount_flange"/>
         <child link="${prefix}tool0"/>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <origin xyz=".055 0 0" rpy="0 1.57079632679 0"/>
     </joint>
     <joint type="fixed" name="${prefix}joint_cylinder">
         <origin xyz="-0.365 -0.1895 0.405" rpy="0 -0.170 0"/>


### PR DESCRIPTION
```
- A link mount_flange is added in the kinematic chain between link_6 and tool0.
- The link orients the frame to match the robot controller allowing tool0 to match
   the robot controller tool0 exactly.
```
