### PR TITLE
Update readme text

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,18 @@
 
 [ROS-Industrial][] ABB meta-package.  See the [ROS wiki][] page for more information.
 
+The [abb_experimental][] repository contains additional packages.
+
+
 ## Contents
 
-This repo holds source code for all versions > groovy. For those versions <= groovy see: [SVN repo][]
+Branch naming follows the ROS distribution they are compatible with. `-devel`
+branches may be unstable. Releases are made from the distribution branches
+(`hydro`, `indigo`).
+
+Older releases may be found in the old ROS-Industrial [subversion repository][].
 
 [ROS-Industrial]: http://www.ros.org/wiki/Industrial
 [ROS wiki]: http://ros.org/wiki/abb
-[SVN repo]: https://code.google.com/p/swri-ros-pkg/source/browse
+[abb_experimental]: https://github.com/ros-industrial/abb_experimental
+[subversion repository]: https://code.google.com/p/swri-ros-pkg/source/browse


### PR DESCRIPTION
This updates the readme to mention the `abb_experimental` repository, and to provide some minor rationale for branch names.

Triggered by #96 and others.

Does not include #97.
