### PR TITLE
Remove abb_driver build_depend on simple_message

### DIFF
--- a/abb_driver/package.xml
+++ b/abb_driver/package.xml
@@ -23,7 +23,6 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>industrial_robot_client</build_depend>
-  <build_depend>simple_message</build_depend>
 
   <run_depend>industrial_robot_client</run_depend>
 </package>


### PR DESCRIPTION
This PR is to address issue #90.