### PR TITLE
Update maintainer tag in all pkgs

### DIFF
--- a/abb/package.xml
+++ b/abb/package.xml
@@ -3,13 +3,13 @@
   <name>abb</name>
   <version>1.2.1</version>
   <description>ROS-Industrial support for ABB manipulators (metapackage).</description>
-  <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
+  <maintainer email="levi.armstrong@swri.org">Levi Armstrong (Southwest Research Institute)</maintainer>
   <license>BSD</license>
   <license>Apache 2.0</license>
   <url type="website">http://ros.org/wiki/abb</url>
   <url type="repository">https://github.com/ros-industrial/abb</url>
   <url type="bugtracker">https://github.com/ros-industrial/abb/issues</url>
-  <author email="shaun.edwards@gmail.com">Shaun Edwards</author>
+  <author>Shaun Edwards</author>
 
   <buildtool_depend>catkin</buildtool_depend>
 

--- a/abb/package.xml
+++ b/abb/package.xml
@@ -3,13 +3,14 @@
   <name>abb</name>
   <version>1.2.1</version>
   <description>ROS-Industrial support for ABB manipulators (metapackage).</description>
+  <author>Shaun Edwards</author>
   <maintainer email="levi.armstrong@swri.org">Levi Armstrong (Southwest Research Institute)</maintainer>
   <license>BSD</license>
   <license>Apache 2.0</license>
+
   <url type="website">http://ros.org/wiki/abb</url>
   <url type="repository">https://github.com/ros-industrial/abb</url>
   <url type="bugtracker">https://github.com/ros-industrial/abb/issues</url>
-  <author>Shaun Edwards</author>
 
   <buildtool_depend>catkin</buildtool_depend>
 
@@ -24,8 +25,8 @@
   <exec_depend>abb_irb6640_moveit_config</exec_depend>
   <exec_depend>abb_resources</exec_depend>
 
-
   <export>
     <metapackage/>
+    <architecture_independent/>
   </export>
 </package>

--- a/abb_driver/package.xml
+++ b/abb_driver/package.xml
@@ -13,8 +13,8 @@
   </description>
   <author>Edward Venator</author>
   <author>Jeremy Zoss</author>
-  <author email="sedwards@swri.org">Shaun Edwards</author>
-  <maintainer email="sedwards@swri.org">Shaun Edwards</maintainer>
+  <author>Shaun Edwards</author>
+  <maintainer email="levi.armstrong@swri.org">Levi Armstrong (Southwest Research Institute)</maintainer>
   <license>BSD</license>
 
   <url type="website">http://ros.org/wiki/abb_driver</url>

--- a/abb_irb2400_moveit_config/package.xml
+++ b/abb_irb2400_moveit_config/package.xml
@@ -13,7 +13,7 @@
     </p>
   </description>
   <author email="assistant@moveit.ros.org">MoveIt Setup Assistant</author>
-  <maintainer email="sedwards@swri.org">Shaun Edwards (Southwest Research Institute)</maintainer>
+  <maintainer email="levi.armstrong@swri.org">Levi Armstrong (Southwest Research Institute)</maintainer>
 
   <license>BSD</license>
 

--- a/abb_irb2400_moveit_plugins/package.xml
+++ b/abb_irb2400_moveit_plugins/package.xml
@@ -19,7 +19,7 @@
   </description>
   <author>G.A. vd. Hoorn (TU Delft Robotics Institute)</author>
   <author email="jzoss@swri.org">Jeremy Zoss</author>
-  <maintainer email="sedwards@swri.org">Shaun Edwards (Southwest Research Institute)</maintainer>
+  <maintainer email="levi.armstrong@swri.org">Levi Armstrong (Southwest Research Institute)</maintainer>
   <license>BSD</license>
 
   <url type="website">http://ros.org/wiki/abb_irb2400_moveit_plugins</url>

--- a/abb_irb2400_support/package.xml
+++ b/abb_irb2400_support/package.xml
@@ -28,7 +28,7 @@
     </p>
   </description>
   <author email="ds____on@swri.org">Dan Solomon (Southwest Research Institute)</author>
-  <maintainer email="sedwards@swri.org">Shaun Edwards (Southwest Research Institute)</maintainer>
+  <maintainer email="levi.armstrong@swri.org">Levi Armstrong (Southwest Research Institute)</maintainer>
   <license>Apache2</license>
 
   <url type="website">http://ros.org/wiki/abb_irb2400_support</url>

--- a/abb_irb4400_support/package.xml
+++ b/abb_irb4400_support/package.xml
@@ -25,7 +25,7 @@
     </p>
   </description>
   <author>Dan Solomon</author>
-  <maintainer email="sedewards@swri.org">Shaun Edwards (SwRI)</maintainer>
+  <maintainer email="levi.armstrong@swri.org">Levi Armstrong (Southwest Research Institute)</maintainer>
   <license>Apache2</license>
 
   <url type="website">http://wiki.ros.org/abb_irb4400_support</url>

--- a/abb_irb5400_support/package.xml
+++ b/abb_irb5400_support/package.xml
@@ -24,7 +24,7 @@
     </p>
   </description>
   <author email="ds____on@swri.org">Dan Solomon (Southwest Research Institute)</author>
-  <maintainer email="sedwards@swri.org">Shaun Edwards (Southwest Research Institute)</maintainer>
+  <maintainer email="levi.armstrong@swri.org">Levi Armstrong (Southwest Research Institute)</maintainer>
   <license>Apache2</license>
 
   <url type="website">http://ros.org/wiki/abb_irb5400_support</url>

--- a/abb_irb6640_moveit_config/package.xml
+++ b/abb_irb6640_moveit_config/package.xml
@@ -13,7 +13,7 @@
     </p>
   </description>
   <author email="assistant@moveit.ros.org">MoveIt Setup Assistant</author>
-  <maintainer email="sedwards@swri.org">Shaun Edwards (Southwest Research Institute)</maintainer>
+  <maintainer email="levi.armstrong@swri.org">Levi Armstrong (Southwest Research Institute)</maintainer>
 
   <license>BSD</license>
 


### PR DESCRIPTION
As per subject.

50c5ec9 marks the meta-package as `architecture independent`, as it should be (was somehow missing).
