### PR TITLE
readme: add 'support level' badge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Build Status](http://build.ros.org/job/Idev__abb__ubuntu_trusty_amd64/badge/icon)](http://build.ros.org/job/Idev__abb__ubuntu_trusty_amd64)
 
+[![support level: community](https://img.shields.io/badge/support%20level-community-lightgray.png)](http://rosindustrial.org/news/2016/10/7/better-supporting-a-growing-ros-industrial-software-platform)
+
 [ROS-Industrial][] ABB meta-package.  See the [ROS wiki][] page for more information.
 
 The [abb_experimental][] repository contains additional packages.


### PR DESCRIPTION
As per subject.

I believe this is the correct badge.

At least at the moment ABB is not (yet) officially supporting this repository.
