### PR TITLE
WIP: Adds robot status publishing

### DIFF
--- a/abb_driver/rapid/ROS_common.sys
+++ b/abb_driver/rapid/ROS_common.sys
@@ -36,9 +36,9 @@ ENDRECORD
 CONST num MAX_TRAJ_LENGTH := 100;
 
 ! These variables should use TestAndSet read/write protection to prevent conflicts
-PERS bool ROS_trajectory_lock := false;
+PERS bool ROS_trajectory_lock := FALSE;
 PERS ROS_joint_trajectory_pt ROS_trajectory{MAX_TRAJ_LENGTH};
 PERS num ROS_trajectory_size := 0;
-PERS bool ROS_new_trajectory := false;       ! can safely READ, but should use lock to WRITE
+PERS bool ROS_new_trajectory := FALSE;       ! can safely READ, but should use lock to WRITE
 
 ENDMODULE

--- a/abb_driver/rapid/ROS_messages.sys
+++ b/abb_driver/rapid/ROS_messages.sys
@@ -81,16 +81,16 @@ CONST num ROS_TRAJECTORY_END := -3;
 CONST num ROS_TRAJECTORY_STOP := -4;
 
 ! Robot mode codes (from industrial_msgs/RobotMode.msg)
-CONST num ROS_ROBOT_MODE_UNKNOWN     := -1   ! Unknown or unavailable
-CONST num ROS_ROBOT_MODE_MANUAL      := 1    ! Teach OR manual mode
-CONST num ROS_ROBOT_MODE_AUTO        := 2    ! Automatic mode
+CONST num ROS_ROBOT_MODE_UNKNOWN     := -1; ! Unknown or unavailable
+CONST num ROS_ROBOT_MODE_MANUAL      := 1;  ! Teach OR manual mode
+CONST num ROS_ROBOT_MODE_AUTO        := 2;  ! Automatic mode
 
 ! Tri-state values (from inudstrial/TriState.msg)
-CONST num ROS_TRISTATE_UNKNOWN       := -1
-CONST num ROS_TRISTATE_TRUE          := 1
-CONST num ROS_TRISTATE_ON            := 1
-CONST num ROS_TRISTATE_FALSE         := 0
-CONST num ROS_TRISTATE_OFF           := 0
+CONST num ROS_TRISTATE_UNKNOWN       := -1;
+CONST num ROS_TRISTATE_TRUE          := 1;
+CONST num ROS_TRISTATE_ON            := 1;
+CONST num ROS_TRISTATE_FALSE         := 0;
+CONST num ROS_TRISTATE_OFF           := 0;
 
 ! Other message constants
 CONST num ROS_MSG_MAX_JOINTS := 10;  ! from joint_data.h
@@ -174,6 +174,30 @@ PROC ROS_send_msg_joint_data(VAR socketdev client_socket, ROS_msg_joint_data mes
 ERROR
     RAISE;  ! raise errors to calling code
 ENDPROC
+
+PROC ROS_send_msg_robot_status(VAR socketdev client_socket, ROS_msg_robot_status message)
+    VAR ROS_msg raw_message;
+
+    ! Force message header to the correct values
+    raw_message.header.msg_type := message.header.msg_type;
+    raw_message.header.comm_type := message.header.comm_type;
+    raw_message.header.reply_code := message.header.reply_code;
+
+    ! Pack data into message
+    PackRawBytes message.drives_powered,     raw_message.data,  1, \IntX:=DINT;
+    PackRawBytes message.e_stopped,          raw_message.data,  5, \IntX:=DINT;
+    PackRawBytes message.error_code,         raw_message.data,  9, \IntX:=DINT;
+    PackRawBytes message.in_error,           raw_message.data, 13, \IntX:=DINT;
+    PackRawBytes message.in_motion,          raw_message.data, 17, \IntX:=DINT;
+    PackRawBytes message.mode,               raw_message.data, 21, \IntX:=DINT;
+    PackRawBytes message.motion_possible,    raw_message.data, 25, \IntX:=DINT;
+    
+    ROS_send_msg client_socket, raw_message;
+
+ERROR
+    RAISE;  ! raise errors to calling code
+ENDPROC
+
 
 LOCAL FUNC num deg2rad(num deg)
     RETURN deg * pi / 180;

--- a/abb_driver/rapid/ROS_messages.sys
+++ b/abb_driver/rapid/ROS_messages.sys
@@ -51,10 +51,23 @@ RECORD ROS_msg_joint_data
     robjoint joints;  ! in DEGREES
 ENDRECORD
 
+RECORD ROS_msg_robot_status
+    ROS_msg_header header;
+    num sequence_id;
+    num drives_powered;
+    num e_stopped;
+    num error_code;
+    num in_error;
+    num in_motion;
+    num mode;
+    num motion_possible;
+ENDRECORD
+
 ! Message Type Codes (from simple_message/simple_message.h)
 CONST num ROS_MSG_TYPE_INVALID       := 0;
 CONST num ROS_MSG_TYPE_JOINT         := 10;  ! joint-position feedback
 CONST num ROS_MSG_TYPE_JOINT_TRAJ_PT := 11;  ! joint-trajectory-point (for path downloading)
+CONST num ROS_MSG_TYPE_STATUS        := 13;  ! robot status message (for reporting the robot state)
 CONST num ROS_COM_TYPE_TOPIC         := 1;
 CONST num ROS_COM_TYPE_SRV_REQ       := 2;
 CONST num ROS_COM_TYPE_SRV_REPLY     := 3;
@@ -67,27 +80,39 @@ CONST num ROS_TRAJECTORY_START_DOWNLOAD := -1;
 CONST num ROS_TRAJECTORY_END := -3;
 CONST num ROS_TRAJECTORY_STOP := -4;
 
+! Robot mode codes (from industrial_msgs/RobotMode.msg)
+CONST num ROS_ROBOT_MODE_UNKNOWN     := -1   ! Unknown or unavailable
+CONST num ROS_ROBOT_MODE_MANUAL      := 1    ! Teach OR manual mode
+CONST num ROS_ROBOT_MODE_AUTO        := 2    ! Automatic mode
+
+! Tri-state values (from inudstrial/TriState.msg)
+CONST num ROS_TRISTATE_UNKNOWN       := -1
+CONST num ROS_TRISTATE_TRUE          := 1
+CONST num ROS_TRISTATE_ON            := 1
+CONST num ROS_TRISTATE_FALSE         := 0
+CONST num ROS_TRISTATE_OFF           := 0
+
 ! Other message constants
 CONST num ROS_MSG_MAX_JOINTS := 10;  ! from joint_data.h
 
 PROC ROS_receive_msg_joint_traj_pt(VAR socketdev client_socket, VAR ROS_msg_joint_traj_pt message, \num wait_time)
     VAR ROS_msg raw_message;
-    
+
     ! Read raw message data
     IF Present(wait_time) THEN
         ROS_receive_msg client_socket, raw_message, \wait_time:=wait_time;
     ELSE
         ROS_receive_msg client_socket, raw_message;
     ENDIF
-    
+
     ! Integrity Check: Message Type
     IF (raw_message.header.msg_type <> ROS_MSG_TYPE_JOINT_TRAJ_PT) THEN
         ErrWrite \W, "ROS Socket Type Mismatch", "Unexpected message type",
-                \RL2:="expected: " + ValToStr(ROS_MSG_TYPE_JOINT_TRAJ_PT),
-                \RL3:="received: " + ValToStr(raw_message.header.msg_type);
+                 \RL2:="expected: " + ValToStr(ROS_MSG_TYPE_JOINT_TRAJ_PT),
+                 \RL3:="received: " + ValToStr(raw_message.header.msg_type);
         RAISE ERR_ARGVALERR;  ! TBD: define specific error code
     ENDIF
-    
+
     ! Integrity Check: Data Size
     IF (RawBytesLen(raw_message.data) < 52) THEN
         ErrWrite \W, "ROS Socket Missing Data", "Insufficient data for joint_trajectory_pt",
@@ -95,10 +120,10 @@ PROC ROS_receive_msg_joint_traj_pt(VAR socketdev client_socket, VAR ROS_msg_join
                 \RL3:="received: " + ValToStr(RawBytesLen(raw_message.data));
         RAISE ERR_OUTOFBND;  ! TBD: define specific error code
     ENDIF
-    
+
     ! Copy Header data
     message.header := raw_message.header;
-    
+
     ! Unpack data fields
     UnpackRawBytes raw_message.data, 1, message.sequence_id, \IntX:=DINT;
     UnpackRawBytes raw_message.data, 5, message.joints.rax_1, \Float4;
@@ -110,11 +135,11 @@ PROC ROS_receive_msg_joint_traj_pt(VAR socketdev client_socket, VAR ROS_msg_join
     ! Skip bytes 29-44.  UNUSED.  Reserved for Joints 7-10.  TBD: copy to extAx?
     UnpackRawBytes raw_message.data, 29+(ROS_MSG_MAX_JOINTS-6)*4, message.velocity, \Float4;
     UnpackRawBytes raw_message.data, 33+(ROS_MSG_MAX_JOINTS-6)*4, message.duration, \Float4;
-    
+
     ! Convert data from ROS units to ABB units
     message.joints := rad2deg_robjoint(message.joints);
     ! TBD: convert velocity
-    
+
 ERROR
     RAISE;  ! raise errors to calling code
 ENDPROC
@@ -123,12 +148,12 @@ PROC ROS_send_msg_joint_data(VAR socketdev client_socket, ROS_msg_joint_data mes
     VAR ROS_msg raw_message;
     VAR robjoint ROS_joints;
     VAR num i;
-    
+
     ! Force message header to the correct values
     raw_message.header.msg_type := ROS_MSG_TYPE_JOINT;
     raw_message.header.comm_type := ROS_COM_TYPE_TOPIC;
     raw_message.header.reply_code := ROS_REPLY_TYPE_INVALID;
-    
+
     ! Convert data from ABB units to ROS units
     ROS_joints := deg2rad_robjoint(message.joints);
 
@@ -178,7 +203,7 @@ LOCAL FUNC robjoint rad2deg_robjoint(robjoint rad)
     deg.rax_4 := rad2deg(rad.rax_4);
     deg.rax_5 := rad2deg(rad.rax_5);
     deg.rax_6 := rad2deg(rad.rax_6);
-    
+
     RETURN deg;
 ENDFUNC
 

--- a/abb_driver/rapid/ROS_motion.mod
+++ b/abb_driver/rapid/ROS_motion.mod
@@ -39,7 +39,7 @@ PROC main()
     VAR speeddata move_speed := v10;  ! default speed
     VAR zonedata stop_mode;
     VAR bool skip_move;
-    
+
     ! Set up interrupt to watch for new trajectory
     IDelete intr_new_trajectory;    ! clear interrupt handler, in case restarted with ExitCycle
     CONNECT intr_new_trajectory WITH new_trajectory_handler;
@@ -67,7 +67,7 @@ PROC main()
 
             trajectory_size := 0;  ! trajectory done
         ENDIF
-        
+
         WaitTime 0.05;  ! Throttle loop while waiting for new command
     ENDWHILE
 ERROR
@@ -79,17 +79,17 @@ LOCAL PROC init_trajectory()
     clear_path;                    ! cancel any active motions
 
     WaitTestAndSet ROS_trajectory_lock;  ! acquire data-lock
-      trajectory := ROS_trajectory;            ! copy to local var
-      trajectory_size := ROS_trajectory_size;  ! copy to local var
-      ROS_new_trajectory := FALSE;
+    trajectory := ROS_trajectory;            ! copy to local var
+    trajectory_size := ROS_trajectory_size;  ! copy to local var
+    ROS_new_trajectory := FALSE;
     ROS_trajectory_lock := FALSE;         ! release data-lock
 ENDPROC
 
 LOCAL FUNC bool is_near(robjoint target, num tol)
     VAR jointtarget curr_jnt;
-    
+
     curr_jnt := CJointT();
-    
+
     RETURN ( ABS(curr_jnt.robax.rax_1 - target.rax_1) < tol )
        AND ( ABS(curr_jnt.robax.rax_2 - target.rax_2) < tol )
        AND ( ABS(curr_jnt.robax.rax_3 - target.rax_3) < tol )
@@ -113,7 +113,7 @@ ENDPROC
 
 LOCAL TRAP new_trajectory_handler
     IF (NOT ROS_new_trajectory) RETURN;
-    
+
     abort_trajectory;
 ENDTRAP
 

--- a/abb_driver/rapid/ROS_motionServer.mod
+++ b/abb_driver/rapid/ROS_motionServer.mod
@@ -39,53 +39,53 @@ PROC main()
     VAR ROS_msg_joint_traj_pt message;
 
     TPWrite "MotionServer: Waiting for connection.";
-	ROS_init_socket server_socket, server_port;
+    ROS_init_socket server_socket, server_port;
     ROS_wait_for_client server_socket, client_socket;
 
     WHILE ( true ) DO
-		! Recieve Joint Trajectory Pt Message
+        ! Recieve Joint Trajectory Pt Message
         ROS_receive_msg_joint_traj_pt client_socket, message;
-		trajectory_pt_callback message;
-	ENDWHILE
+        trajectory_pt_callback message;
+    ENDWHILE
 
 ERROR (ERR_SOCK_TIMEOUT, ERR_SOCK_CLOSED)
-	IF (ERRNO=ERR_SOCK_TIMEOUT) OR (ERRNO=ERR_SOCK_CLOSED) THEN
+    IF (ERRNO=ERR_SOCK_TIMEOUT) OR (ERRNO=ERR_SOCK_CLOSED) THEN
         SkipWarn;  ! TBD: include this error data in the message logged below?
         ErrWrite \W, "ROS MotionServer disconnect", "Connection lost.  Resetting socket.";
-		ExitCycle;  ! restart program
-	ELSE
-		TRYNEXT;
-	ENDIF
+        ExitCycle;  ! restart program
+    ELSE
+        TRYNEXT;
+    ENDIF
 UNDO
-	IF (SocketGetStatus(client_socket) <> SOCKET_CLOSED) SocketClose client_socket;
-	IF (SocketGetStatus(server_socket) <> SOCKET_CLOSED) SocketClose server_socket;
+    IF (SocketGetStatus(client_socket) <> SOCKET_CLOSED) SocketClose client_socket;
+    IF (SocketGetStatus(server_socket) <> SOCKET_CLOSED) SocketClose server_socket;
 ENDPROC
 
 LOCAL PROC trajectory_pt_callback(ROS_msg_joint_traj_pt message)
-	VAR ROS_joint_trajectory_pt point;
-	VAR jointtarget current_pos;
+    VAR ROS_joint_trajectory_pt point;
+    VAR jointtarget current_pos;
     VAR ROS_msg reply_msg;
 
     point := [message.joints, message.duration];
-    
+
     ! use sequence_id to signal start/end of trajectory download
-	TEST message.sequence_id
-		CASE ROS_TRAJECTORY_START_DOWNLOAD:
+    TEST message.sequence_id
+        CASE ROS_TRAJECTORY_START_DOWNLOAD:
             TPWrite "Traj START received";
-			trajectory_size := 0;                 ! Reset trajectory size
+            trajectory_size := 0;                 ! Reset trajectory size
             add_traj_pt point;                    ! Add this point to the trajectory
-		CASE ROS_TRAJECTORY_END:
+        CASE ROS_TRAJECTORY_END:
             TPWrite "Traj END received";
             add_traj_pt point;                    ! Add this point to the trajectory
             activate_trajectory;
-		CASE ROS_TRAJECTORY_STOP:
+        CASE ROS_TRAJECTORY_STOP:
             TPWrite "Traj STOP received";
             trajectory_size := 0;  ! empty trajectory
             activate_trajectory;
             StopMove; ClearPath; StartMove;  ! redundant, but re-issue stop command just to be safe
-		DEFAULT:
+        DEFAULT:
             add_traj_pt point;                    ! Add this point to the trajectory
-	ENDTEST
+    ENDTEST
 
     ! send reply, if requested
     IF (message.header.comm_type = ROS_COM_TYPE_SRV_REQ) THEN
@@ -100,7 +100,7 @@ ENDPROC
 LOCAL PROC add_traj_pt(ROS_joint_trajectory_pt point)
     IF (trajectory_size = MAX_TRAJ_LENGTH) THEN
         ErrWrite \W, "Too Many Trajectory Points", "Trajectory has already reached its maximum size",
-            \RL2:="max_size = " + ValToStr(MAX_TRAJ_LENGTH);
+                 \RL2:="max_size = " + ValToStr(MAX_TRAJ_LENGTH);
     ELSE
         Incr trajectory_size;
         trajectory{trajectory_size} := point; !Add this point to the trajectory
@@ -115,5 +115,5 @@ LOCAL PROC activate_trajectory()
     ROS_new_trajectory := TRUE;
     ROS_trajectory_lock := FALSE;  ! release data-lock
 ENDPROC
-	
+
 ENDMODULE

--- a/abb_driver/rapid/ROS_socket.sys
+++ b/abb_driver/rapid/ROS_socket.sys
@@ -29,7 +29,7 @@ MODULE ROS_socket(SYSMODULE)
 
 PROC ROS_init_socket(VAR socketdev server_socket, num port)
     IF (SocketGetStatus(server_socket) = SOCKET_CLOSED) SocketCreate server_socket;
-    IF (SocketGetStatus(server_socket) = SOCKET_CREATED) SocketBind server_socket, GetSysInfo(\LanIp), port;
+    IF (SocketGetStatus(server_socket) = SOCKET_CREATED) SocketBind server_socket, "192.168.1.42", port;
     IF (SocketGetStatus(server_socket) = SOCKET_BOUND) SocketListen server_socket;
 
 ERROR


### PR DESCRIPTION
This is a first start at addressing the enhancement originally identified in #34. I am the furthest thing from a RAPID expert that you could possibly find, but I scoured their technical manual and think I have the right API calls to populate the various fields in the robot status message.

Besides better ways I could be doing things, the one known issue I have currently is how to best populate the `in_motion` flag. My first idea was to just grab the state of the `ROS_new_trajectory` boolean. While this better represents a "motion eminent" state rather than strictly "in motion", I thought it would be a good approximation. However when I tested this logic on hardware, the robot refused to execute any commanded trajectory. My guess is there is maybe a race condition in some trajectory monitoring logic somewhere. If it is a race, it would be compounded by other issues we are currently having (#142). That is the best I can come up with...

How do other industrial robots handle `in_motion`? Are they more sensor driven? For instance looking at joint velocities or estimating joint velocities? In my cursory search through the ABB literature, I couldn't find pre-made signal to easily populate this field.

Other than help on this specific field, I know I will need to make a PR to update the tutorial wiki (http://wiki.ros.org/abb/Tutorials/InstallServer) as this solution does require setting up some signals in RobotStudio's System Configuration.