### PR TITLE
Add support for external axes on the ABB driver

### DIFF
--- a/abb_driver/rapid/ROS_common.sys
+++ b/abb_driver/rapid/ROS_common.sys
@@ -30,6 +30,7 @@ MODULE ROS_common(SYSMODULE)
 
 RECORD ROS_joint_trajectory_pt
 	robjoint joint_pos;
+    extjoint extax_pos;
 	num duration;
 ENDRECORD
 

--- a/abb_driver/rapid/ROS_messages.sys
+++ b/abb_driver/rapid/ROS_messages.sys
@@ -118,6 +118,7 @@ PROC ROS_receive_msg_joint_traj_pt(VAR socketdev client_socket, VAR ROS_msg_join
 
     ! Convert data from ROS units to ABB units
     message.joints := rad2deg_robjoint(message.joints);
+    message.ext_axes := m2mm_extjoint(message.ext_axes);
     ! TBD: convert velocity
     
 ERROR
@@ -137,7 +138,7 @@ PROC ROS_send_msg_joint_data(VAR socketdev client_socket, ROS_msg_joint_data mes
     
     ! Convert data from ABB units to ROS units
     ROS_joints := deg2rad_robjoint(message.joints);
-    ROS_ext_axes := connected_ext_axes(message.ext_axes);
+    ROS_ext_axes := mm2m_extjoint(message.ext_axes);
 
     ! Pack data into message
     PackRawBytes message.sequence_id, raw_message.data,  1, \IntX:=DINT;
@@ -170,14 +171,25 @@ LOCAL FUNC num connected_eax(num eax)
     RETURN 0;
 ENDFUNC
 
-! Returns only connected external axes
-LOCAL FUNC extjoint connected_ext_axes(extjoint all_eax)
+! Returns only connected external axes in METERS
+LOCAL FUNC extjoint mm2m_extjoint(extjoint all_eax)
     VAR extjoint eax;
-    eax.eax_a := connected_eax(all_eax.eax_a);
-    eax.eax_b := connected_eax(all_eax.eax_b);
-    eax.eax_c := connected_eax(all_eax.eax_c);
-    eax.eax_d := connected_eax(all_eax.eax_d);
+    eax.eax_a := connected_eax(all_eax.eax_a) / 1000;
+    eax.eax_b := connected_eax(all_eax.eax_b) / 1000;
+    eax.eax_c := connected_eax(all_eax.eax_c) / 1000;
+    eax.eax_d := connected_eax(all_eax.eax_d) / 1000;
     RETURN eax;
+ENDFUNC
+
+! Returns external axes in MILLIMETERS
+LOCAL FUNC extjoint m2mm_extjoint(extjoint eax_in_m)
+    VAR extjoint eax_in_mm;
+    eax_in_mm.eax_a := eax_in_m.eax_a * 1000;
+    eax_in_mm.eax_b := eax_in_m.eax_b * 1000;
+    eax_in_mm.eax_c := eax_in_m.eax_c * 1000;
+    eax_in_mm.eax_d := eax_in_m.eax_d * 1000;
+    
+    RETURN eax_in_mm;
 ENDFUNC
 
 LOCAL FUNC robjoint deg2rad_robjoint(robjoint deg)

--- a/abb_driver/rapid/ROS_messages.sys
+++ b/abb_driver/rapid/ROS_messages.sys
@@ -41,6 +41,7 @@ RECORD ROS_msg_joint_traj_pt
     ROS_msg_header header;
     num sequence_id;
     robjoint joints;  ! in DEGREES
+    extjoint ext_axes;
     num velocity;
     num duration;
 ENDRECORD
@@ -49,6 +50,7 @@ RECORD ROS_msg_joint_data
     ROS_msg_header header;
     num sequence_id;
     robjoint joints;  ! in DEGREES
+    extjoint ext_axes;
 ENDRECORD
 
 ! Message Type Codes (from simple_message/simple_message.h)
@@ -107,10 +109,13 @@ PROC ROS_receive_msg_joint_traj_pt(VAR socketdev client_socket, VAR ROS_msg_join
     UnpackRawBytes raw_message.data, 17, message.joints.rax_4, \Float4;
     UnpackRawBytes raw_message.data, 21, message.joints.rax_5, \Float4;
     UnpackRawBytes raw_message.data, 25, message.joints.rax_6, \Float4;
-    ! Skip bytes 29-44.  UNUSED.  Reserved for Joints 7-10.  TBD: copy to extAx?
-    UnpackRawBytes raw_message.data, 29+(ROS_MSG_MAX_JOINTS-6)*4, message.velocity, \Float4;
-    UnpackRawBytes raw_message.data, 33+(ROS_MSG_MAX_JOINTS-6)*4, message.duration, \Float4;
-    
+    UnpackRawBytes raw_message.data, 29, message.ext_axes.eax_a, \Float4;
+    UnpackRawBytes raw_message.data, 33, message.ext_axes.eax_b, \Float4;
+    UnpackRawBytes raw_message.data, 37, message.ext_axes.eax_c, \Float4;
+    UnpackRawBytes raw_message.data, 41, message.ext_axes.eax_d, \Float4;
+    UnpackRawBytes raw_message.data, 45, message.velocity, \Float4;
+    UnpackRawBytes raw_message.data, 49, message.duration, \Float4;
+
     ! Convert data from ROS units to ABB units
     message.joints := rad2deg_robjoint(message.joints);
     ! TBD: convert velocity
@@ -122,6 +127,7 @@ ENDPROC
 PROC ROS_send_msg_joint_data(VAR socketdev client_socket, ROS_msg_joint_data message)
     VAR ROS_msg raw_message;
     VAR robjoint ROS_joints;
+    VAR extjoint ROS_ext_axes;
     VAR num i;
     
     ! Force message header to the correct values
@@ -131,6 +137,7 @@ PROC ROS_send_msg_joint_data(VAR socketdev client_socket, ROS_msg_joint_data mes
     
     ! Convert data from ABB units to ROS units
     ROS_joints := deg2rad_robjoint(message.joints);
+    ROS_ext_axes := connected_ext_axes(message.ext_axes);
 
     ! Pack data into message
     PackRawBytes message.sequence_id, raw_message.data,  1, \IntX:=DINT;
@@ -140,9 +147,10 @@ PROC ROS_send_msg_joint_data(VAR socketdev client_socket, ROS_msg_joint_data mes
     PackRawBytes ROS_joints.rax_4,    raw_message.data, 17, \Float4;
     PackRawBytes ROS_joints.rax_5,    raw_message.data, 21, \Float4;
     PackRawBytes ROS_joints.rax_6,    raw_message.data, 25, \Float4;
-    FOR i FROM 1 TO ROS_MSG_MAX_JOINTS-6 DO   ! Insert placeholders for joints 7-10 (message expects 10 joints)
-        PackRawBytes 0,               raw_message.data, 25+i*4, \Float4;
-    ENDFOR
+    PackRawBytes ROS_ext_axes.eax_a,  raw_message.data, 29, \Float4;
+    PackRawBytes ROS_ext_axes.eax_b,  raw_message.data, 33, \Float4;
+    PackRawBytes ROS_ext_axes.eax_c,  raw_message.data, 37, \Float4;
+    PackRawBytes ROS_ext_axes.eax_d,  raw_message.data, 41, \Float4;
 
     ROS_send_msg client_socket, raw_message;
 
@@ -152,6 +160,24 @@ ENDPROC
 
 LOCAL FUNC num deg2rad(num deg)
     RETURN deg * pi / 180;
+ENDFUNC
+
+LOCAL FUNC num connected_eax(num eax)
+    ! The value 9E9 is defined for axes which are not connected
+    IF eax <> 9E9 THEN
+        RETURN eax;
+    ENDIF
+    RETURN 0;
+ENDFUNC
+
+! Returns only connected external axes
+LOCAL FUNC extjoint connected_ext_axes(extjoint all_eax)
+    VAR extjoint eax;
+    eax.eax_a := connected_eax(all_eax.eax_a);
+    eax.eax_b := connected_eax(all_eax.eax_b);
+    eax.eax_c := connected_eax(all_eax.eax_c);
+    eax.eax_d := connected_eax(all_eax.eax_d);
+    RETURN eax;
 ENDFUNC
 
 LOCAL FUNC robjoint deg2rad_robjoint(robjoint deg)

--- a/abb_driver/rapid/ROS_motion.mod
+++ b/abb_driver/rapid/ROS_motion.mod
@@ -54,6 +54,7 @@ PROC main()
         IF (trajectory_size > 0) THEN
             FOR current_index FROM 1 TO trajectory_size DO
                 target.robax := trajectory{current_index}.joint_pos;
+                target.extax := trajectory{current_index}.extax_pos;
 
                 skip_move := (current_index = 1) AND is_near(target.robax, 0.1);
 

--- a/abb_driver/rapid/ROS_motion.mod
+++ b/abb_driver/rapid/ROS_motion.mod
@@ -56,7 +56,7 @@ PROC main()
                 target.robax := trajectory{current_index}.joint_pos;
                 target.extax := trajectory{current_index}.extax_pos;
 
-                skip_move := (current_index = 1) AND is_near(target.robax, 0.1);
+                skip_move := (current_index = 1) AND is_near(target, 0.1, 0.1);
 
                 stop_mode := DEFAULT_CORNER_DIST;  ! assume we're smoothing between points
                 IF (current_index = trajectory_size) stop_mode := fine;  ! stop at path end
@@ -86,17 +86,21 @@ LOCAL PROC init_trajectory()
     ROS_trajectory_lock := FALSE;         ! release data-lock
 ENDPROC
 
-LOCAL FUNC bool is_near(robjoint target, num tol)
+LOCAL FUNC bool is_near(jointtarget target, num deg_tol, num mm_tol)
     VAR jointtarget curr_jnt;
     
     curr_jnt := CJointT();
     
-    RETURN ( ABS(curr_jnt.robax.rax_1 - target.rax_1) < tol )
-       AND ( ABS(curr_jnt.robax.rax_2 - target.rax_2) < tol )
-       AND ( ABS(curr_jnt.robax.rax_3 - target.rax_3) < tol )
-       AND ( ABS(curr_jnt.robax.rax_4 - target.rax_4) < tol )
-       AND ( ABS(curr_jnt.robax.rax_5 - target.rax_5) < tol )
-       AND ( ABS(curr_jnt.robax.rax_6 - target.rax_6) < tol );
+    RETURN ( ABS(curr_jnt.robax.rax_1 - target.robax.rax_1) < deg_tol )
+       AND ( ABS(curr_jnt.robax.rax_2 - target.robax.rax_2) < deg_tol )
+       AND ( ABS(curr_jnt.robax.rax_3 - target.robax.rax_3) < deg_tol )
+       AND ( ABS(curr_jnt.robax.rax_4 - target.robax.rax_4) < deg_tol )
+       AND ( ABS(curr_jnt.robax.rax_5 - target.robax.rax_5) < deg_tol )
+       AND ( ABS(curr_jnt.robax.rax_6 - target.robax.rax_6) < deg_tol )
+       AND ( ABS(curr_jnt.extax.eax_a - target.extax.eax_a) < mm_tol )
+       AND ( ABS(curr_jnt.extax.eax_b - target.extax.eax_b) < mm_tol )
+       AND ( ABS(curr_jnt.extax.eax_c - target.extax.eax_c) < mm_tol )
+       AND ( ABS(curr_jnt.extax.eax_d - target.extax.eax_d) < mm_tol );
 ENDFUNC
 
 LOCAL PROC abort_trajectory()

--- a/abb_driver/rapid/ROS_motionServer.mod
+++ b/abb_driver/rapid/ROS_motionServer.mod
@@ -66,7 +66,7 @@ LOCAL PROC trajectory_pt_callback(ROS_msg_joint_traj_pt message)
 	VAR jointtarget current_pos;
     VAR ROS_msg reply_msg;
 
-    point := [message.joints, message.duration];
+    point := [message.joints, message.ext_axes, message.duration];
     
     ! use sequence_id to signal start/end of trajectory download
 	TEST message.sequence_id

--- a/abb_driver/rapid/ROS_stateServer.mod
+++ b/abb_driver/rapid/ROS_stateServer.mod
@@ -67,6 +67,7 @@ LOCAL PROC send_joints()
     message.header := [ROS_MSG_TYPE_JOINT, ROS_COM_TYPE_TOPIC, ROS_REPLY_TYPE_INVALID];
     message.sequence_id := 0;
     message.joints := joints.robax;
+    message.ext_axes := joints.extax;
     
     ! send message to client
     ROS_send_msg_joint_data client_socket, message;


### PR DESCRIPTION
As discussed on https://github.com/ros-industrial/abb/issues/135, here's a proposal for integrated external axes support on the ABB driver. I tested on IRB4600 real hardware on a linear track.

* Motion server now takes into account all 4 additional joints present in the message and assigned them to `eax_a`, `eax_b`, `eax_c` and `eax_d`.
* Status server sends all connected external axes. Non-connected are zero filled.

I explicitly did not change tabs to spaces in places where it would have been logical to do so (e.g. `ROS_common.sys`) to avoid merge conflicts with https://github.com/ros-industrial/abb/pull/145

