### PR TITLE
Replace `xacro.py` to `xacro --inorder`

### DIFF
--- a/abb_irb6640_support/launch/load_irb6640_185_280.launch
+++ b/abb_irb6640_support/launch/load_irb6640_185_280.launch
@@ -1,3 +1,3 @@
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro.py '$(find abb_irb6640_support)/urdf/irb6640_185_280.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find abb_irb6640_support)/urdf/irb6640_185_280.xacro'" />
 </launch>


### PR DESCRIPTION
This PR fixes https://github.com/ros-industrial/industrial_training/issues/220 issue.

Environment:
- OS: Ubuntu 16.04
- ROS: Kinetic