### PR TITLE
Update URDF shared pointers for melodic

### DIFF
--- a/abb_irb2400_moveit_plugins/irb2400_kinematics/src/abb_irb2400_manipulator_ikfast_moveit_plugin.cpp
+++ b/abb_irb2400_moveit_plugins/irb2400_kinematics/src/abb_irb2400_manipulator_ikfast_moveit_plugin.cpp
@@ -299,12 +299,12 @@ bool IKFastKinematicsPlugin::initialize(const std::string &robot_description,
 
   ROS_DEBUG_STREAM_NAMED("ikfast","Reading joints and links from URDF");
 
-  boost::shared_ptr<urdf::Link> link = boost::const_pointer_cast<urdf::Link>(robot_model.getLink(getTipFrame()));
+  urdf::LinkSharedPtr link = urdf::const_pointer_cast<urdf::Link>(robot_model.getLink(getTipFrame()));
   while(link->name != base_frame_ && joint_names_.size() <= num_joints_)
   {
     ROS_DEBUG_NAMED("ikfast","Link %s",link->name.c_str());
     link_names_.push_back(link->name);
-    boost::shared_ptr<urdf::Joint> joint = link->parent_joint;
+    urdf::JointSharedPtr joint = link->parent_joint;
     if(joint)
     {
       if (joint->type != urdf::Joint::UNKNOWN && joint->type != urdf::Joint::FIXED)


### PR DESCRIPTION
Starting in melodic, URDF library uses `std::shared_ptr` instead of `boost::shared_ptr`. It provides a typdef though, so this fix should be backwards compatible to kinetic, and no new melodic branch is needed.