### PR TITLE
Adding Olive Green as a color

### DIFF
--- a/abb_resources/urdf/common_colours.xacro
+++ b/abb_resources/urdf/common_colours.xacro
@@ -39,7 +39,7 @@
   <xacro:property name="colour_abb_leaf_green" value="0.1764706 0.3529412 0.1529412 1" />
 
   <!-- RAL 6003 olive green -->
-  <xacro:property name="colour_abb_olive_green" value="0.3137254 0.3254902 0.2352941 1" />
+  <xacro:property name="colour_abb_olive_green" value="${ 80/255} ${ 83/255} ${ 60/255} 1" />
 
   <!-- RAL 9002 gray white -->
   <xacro:property name="colour_abb_gray_white" value="0.8392157 0.8352941 0.7921569 1" />

--- a/abb_resources/urdf/common_colours.xacro
+++ b/abb_resources/urdf/common_colours.xacro
@@ -38,6 +38,9 @@
   <!-- RAL 6002 leaf green -->
   <xacro:property name="colour_abb_leaf_green" value="0.1764706 0.3529412 0.1529412 1" />
 
+  <!-- RAL 6003 olive green -->
+  <xacro:property name="colour_abb_olive_green" value="0.3137254 0.3254902 0.2352941 1" />
+
   <!-- RAL 9002 gray white -->
   <xacro:property name="colour_abb_gray_white" value="0.8392157 0.8352941 0.7921569 1" />
 

--- a/abb_resources/urdf/common_materials.xacro
+++ b/abb_resources/urdf/common_materials.xacro
@@ -68,6 +68,12 @@
     </material>
   </xacro:macro>
 
+  <xacro:macro name="material_abb_olive_green">
+    <material name="">
+      <color rgba="${colour_abb_olive_green}"/>
+    </material>
+  </xacro:macro>
+
   <xacro:macro name="material_abb_gray_white">
     <material name="">
       <color rgba="${colour_abb_gray_white}"/>


### PR DESCRIPTION
I added Olive Green RAL 6003 to the abb common colors list.  I don't know how common it is, but it is able to be ordered from ABB.