### PR TITLE
readme: show Kinetic job status in Kinetic readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ABB
 
-[![Build Status](http://build.ros.org/job/Idev__abb__ubuntu_trusty_amd64/badge/icon)](http://build.ros.org/job/Idev__abb__ubuntu_trusty_amd64)
+[![Build Status](http://build.ros.org/job/Kdev__abb__ubuntu_xenial_amd64/badge/icon)](http://build.ros.org/job/Kdev__abb__ubuntu_xenial_amd64)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 


### PR DESCRIPTION
As per subject.

Note that the build is currently `failing`, but that is because the last build on the ROS buildfarm was somewhere May of this year.
