### PR TITLE
rapid: increase state publish rate to 50 Hz

### DIFF
--- a/abb_driver/rapid/ROS_stateServer.mod
+++ b/abb_driver/rapid/ROS_stateServer.mod
@@ -29,7 +29,7 @@ MODULE ROS_stateServer
 ! WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 LOCAL CONST num server_port := 11002;
-LOCAL CONST num update_rate := 0.10;  ! broadcast rate (sec)
+LOCAL CONST num update_rate := 0.02;  ! broadcast rate (sec)
 
 LOCAL VAR socketdev server_socket;
 LOCAL VAR socketdev client_socket;


### PR DESCRIPTION
As per subject.

10 Hz is rather low, and the controller should have no trouble running this at 50 Hz.

Draft as I have to verify this on real HW.
