### PR TITLE
Increase minimum CMake version to allow builds on Focal Fossa (Noetic)

### DIFF
--- a/abb/CMakeLists.txt
+++ b/abb/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(abb)
 find_package(catkin REQUIRED)
 catkin_metapackage()

--- a/abb_irb2400_moveit_config/CMakeLists.txt
+++ b/abb_irb2400_moveit_config/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(abb_irb2400_moveit_config)
 
 find_package(catkin REQUIRED)

--- a/abb_irb2400_moveit_plugins/CMakeLists.txt
+++ b/abb_irb2400_moveit_plugins/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(abb_irb2400_moveit_plugins)
 add_definitions(-std=c++11)
 

--- a/abb_irb2400_support/CMakeLists.txt
+++ b/abb_irb2400_support/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(abb_irb2400_support)
 
 find_package(catkin REQUIRED)

--- a/abb_irb4400_support/CMakeLists.txt
+++ b/abb_irb4400_support/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(abb_irb4400_support)
 
 find_package(catkin REQUIRED)

--- a/abb_irb5400_support/CMakeLists.txt
+++ b/abb_irb5400_support/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(abb_irb5400_support)
 
 find_package(catkin REQUIRED)

--- a/abb_irb6600_support/CMakeLists.txt
+++ b/abb_irb6600_support/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(abb_irb6600_support)
 
 find_package(catkin REQUIRED)

--- a/abb_irb6640_moveit_config/CMakeLists.txt
+++ b/abb_irb6640_moveit_config/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(abb_irb6640_moveit_config)
 add_definitions(-std=c++11)
 

--- a/abb_irb6640_support/CMakeLists.txt
+++ b/abb_irb6640_support/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(abb_irb6640_support)
 
 find_package(catkin REQUIRED)

--- a/abb_resources/CMakeLists.txt
+++ b/abb_resources/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(abb_resources)
 
 find_package(catkin REQUIRED)


### PR DESCRIPTION
Related to https://github.com/ros-industrial/ros_industrial_issues/issues/67