### PR TITLE
stop enforcing c++ 11

### DIFF
--- a/abb_irb2400_moveit_plugins/CMakeLists.txt
+++ b/abb_irb2400_moveit_plugins/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(abb_irb2400_moveit_plugins)
-add_definitions(-std=c++11)
 
 find_package(catkin REQUIRED COMPONENTS
   moveit_core

--- a/abb_irb6640_moveit_config/CMakeLists.txt
+++ b/abb_irb6640_moveit_config/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(abb_irb6640_moveit_config)
-add_definitions(-std=c++11)
 
 find_package(catkin REQUIRED)
 


### PR DESCRIPTION
Melodic defaults to C++14 already, ROS one requires C++ 17 due to log4cxx, so C++ 11 should not be enforced