### PR TITLE
Don't 'force' C++11 in a MoveIt configuration package (replacement for #192)

### DIFF
--- a/moveit/abb_irb6640_moveit_config/CMakeLists.txt
+++ b/moveit/abb_irb6640_moveit_config/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(abb_irb6640_moveit_config)
-add_definitions(-std=c++11)
 
 find_package(catkin REQUIRED)
 


### PR DESCRIPTION
As per title.

There's no C++ in the MoveIt package, so this serves no purpose.

Replacement for #192.
