### PR TITLE
irb5400: fix joint names in the `xacro:macro` (rebased & fixed #198)

### DIFF
--- a/abb_irb5400_support/urdf/irb5400_macro.xacro
+++ b/abb_irb5400_support/urdf/irb5400_macro.xacro
@@ -120,50 +120,50 @@
     <!-- end of link list -->
 
     <!-- joint list -->
-    <joint name="${prefix}joint1" type="revolute">
+    <joint name="${prefix}joint_1" type="revolute">
         <parent link="${prefix}base_link"/>
         <child link="${prefix}link_1"/>
         <origin xyz="0 0 0" rpy="0 0 0"/>
         <axis xyz="0 0 1"/>
         <limit lower="-2.617" upper="2.617" effort="100" velocity="2.3911"/>
     </joint>
-    <joint name="${prefix}joint2" type="revolute">
+    <joint name="${prefix}joint_2" type="revolute">
         <parent link="${prefix}link_1"/>
         <child link="${prefix}link_2"/>
         <origin xyz="0.300 0 0.660" rpy="0 0 0"/>
         <axis xyz="0 1 0"/>
         <limit lower="-1.396" upper="1.396" effort="100" velocity="2.3911"/>
     </joint>
-    <joint name="${prefix}joint3" type="revolute">
+    <joint name="${prefix}joint_3" type="revolute">
         <parent link="${prefix}link_2"/>
         <child link="${prefix}link_3"/>
         <origin xyz="0 0 1.200" rpy="0 0 0"/>
         <axis xyz="0 1 0"/>
         <limit lower="-1.308" upper="1.308" effort="100" velocity="2.3911"/>
     </joint>
-    <joint name="${prefix}joint4" type="revolute">
+    <joint name="${prefix}joint_4" type="revolute">
         <parent link="${prefix}link_3"/>
         <child link="${prefix}link_4"/>
         <origin xyz="1.339 0 0.186" rpy="0 0 0"/>
         <axis xyz="1 0 0"/>
         <limit lower="-6.0" upper="6.0" effort="100" velocity="8.1157"/>
     </joint>
-    <joint name="${prefix}joint5" type="revolute">
+    <joint name="${prefix}joint_5" type="revolute">
         <parent link="${prefix}link_4"/>
         <child link="${prefix}link_5"/>
         <origin xyz="0.0693 0 0" rpy="0 0.6109 0"/>
         <axis xyz="1 0 0"/>
         <limit lower="-6.0" upper="6.0" effort="100" velocity="6.1086"/>
     </joint>
-    <joint name="${prefix}joint5b" type="revolute">
+    <joint name="${prefix}joint_5b" type="revolute">
         <parent link="${prefix}link_5"/>
         <child link="${prefix}link_5b"/>
         <origin xyz=".106246 0 0.074394" rpy="0 -1.2217 0"/>
         <axis xyz="1 0 0"/>
         <limit lower="-6.0" upper="6.0" effort="100" velocity="6.1086"/>
-        <mimic joint="joint5" multiplier="-1.0" offset="0"/>
+        <mimic joint="joint_5" multiplier="-1.0" offset="0"/>
     </joint>
-    <joint name="${prefix}joint6" type="revolute">
+    <joint name="${prefix}joint_6" type="revolute">
         <parent link="${prefix}link_5b"/>
         <child link="${prefix}link_6"/>
         <origin xyz="0.0672 0 -0.0470" rpy="0 0.6109 0"/>


### PR DESCRIPTION
As per title.

Commit provenance and attribution retained.
