### PR TITLE
ci: don't build `abb_driver` from source and ignore MoveIt pkgs when linting

### DIFF
--- a/.github/workflows/ci_focal.yml
+++ b/.github/workflows/ci_focal.yml
@@ -22,7 +22,7 @@ jobs:
 
     env:
       CATKIN_LINT: true
-      CATKIN_LINT_ARGS: --ignore launch_depend --ignore unconfigured_build_depend
+      CATKIN_LINT_ARGS: --skip-path "abb/moveit/abb"
       CCACHE_DIR: "${{ github.workspace }}/.ccache"
       # using abb_driver from source as it hasn't been released for Noetic
       UPSTREAM_WORKSPACE: 'github:ros-industrial/abb_driver#melodic-devel'

--- a/.github/workflows/ci_focal.yml
+++ b/.github/workflows/ci_focal.yml
@@ -24,8 +24,6 @@ jobs:
       CATKIN_LINT: true
       CATKIN_LINT_ARGS: --skip-path "abb/moveit/abb"
       CCACHE_DIR: "${{ github.workspace }}/.ccache"
-      # using abb_driver from source as it hasn't been released for Noetic
-      UPSTREAM_WORKSPACE: 'github:ros-industrial/abb_driver#melodic-devel'
 
     steps:
       - name: Fetch repository


### PR DESCRIPTION
As per title.
